### PR TITLE
Fix bleeding corners in tables

### DIFF
--- a/src/css/lib/tables.css
+++ b/src/css/lib/tables.css
@@ -49,3 +49,19 @@ td:last-child,
 th:last-child {
   border-right: 0;
 }
+
+tr:last-child td:first-child {
+  border-bottom-left-radius: var(--border-radius);
+}
+
+tr:last-child td:last-child {
+  border-bottom-right-radius: var(--border-radius);
+}
+
+th:first-child {
+  border-top-left-radius: var(--border-radius);
+}
+
+th:last-child {
+  border-top-right-radius: var(--border-radius);
+}

--- a/src/css/lib/tables.css
+++ b/src/css/lib/tables.css
@@ -45,7 +45,7 @@ tr:last-child td {
   border-bottom: 0;
 }
 
-tr td:last-child,
-tr th:last-child {
+td:last-child,
+th:last-child {
   border-right: 0;
 }

--- a/src/css/lib/tables.css
+++ b/src/css/lib/tables.css
@@ -37,8 +37,8 @@ td {
 td { vertical-align: top }
 
 th,
-tbody tr:nth-child(2n) td {
-  background-color: var(--off-white)
+tr:nth-child(even) td {
+  background-color: var(--off-white);
 }
 
 tr:last-child td {


### PR DESCRIPTION
i know it's just a minor thing, but i drives me crazy :D

**before:**
![screen shot 2015-06-26 at 19 53 33](https://cloud.githubusercontent.com/assets/482542/8383853/2af2890a-1c3d-11e5-9308-3ef4b0ea71c9.png)

**after:**
![screen shot 2015-06-26 at 19 52 51](https://cloud.githubusercontent.com/assets/482542/8383852/2aeea79a-1c3d-11e5-8313-37872bb24897.png)

this also leads more or less to a question, since there is also the cheap way and fix it:

```css
table {
  overflow:hidden;
}
```

which i'm not a big fan o,
what do you think?